### PR TITLE
version larger than 1.18 required

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/mattn/zig-update
 
-go 1.17
+go 1.19
 
-require github.com/avvmoto/buf-readerat v0.0.0-20171115124131-a17c8cb89270 // indirect
+require github.com/avvmoto/buf-readerat v0.0.0-20171115124131-a17c8cb89270


### PR DESCRIPTION
Currently go1.17 is specified, but it should be go1.18 or higher.
```
$ go version
go version go1.18.1 darwin/amd64
$ go install github.com/mattn/zig-update@latest
# github.com/mattn/zig-update
../go/pkg/mod/github.com/mattn/zig-update@v0.0.0-20220723182839-6bd4b28b257b/main.go:135:19: undeclared name: any (requires version go1.18 or later)
$ go1.17.10 install github.com/mattn/zig-update@latest
# github.com/mattn/zig-update
../go/pkg/mod/github.com/mattn/zig-update@v0.0.0-20220723182839-6bd4b28b257b/main.go:135:19: undefined: any
../go/pkg/mod/github.com/mattn/zig-update@v0.0.0-20220723182839-6bd4b28b257b/main.go:160:11: assignment mismatch: 2 variables but 1 value
```